### PR TITLE
Add support for SteamDeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LaptopBatteryStatus
-
+
+
 ![Image](https://i.imgur.com/buuPQel.png)
 
 
@@ -10,8 +11,9 @@ Also an optional autosave when below a defined percent, to the filename "Battery
 
 If you use this mod on a computer without a battery, it will just show ”No battery” instead.
 
-Technically it uses a built in function of Unity (Rimworlds framework) so it should be usable on any platform.
+On most platforms, this mod uses a built in function of Unity (Rimworld's framework). When running on a SteamDeck in SteamOS, Unity's battery functions don't provide accurate information, so the mod now uses information exposed by the Linux kernel via sysfs.
 
+- SteamDeck support by [Patrick Watson](https://github.com/watson81)
 - Russian translation by Baknamy
 - Chinese translation by Huiqing998 
 

--- a/Source/LaptopBatteryStatus/HarmonyPatches.cs
+++ b/Source/LaptopBatteryStatus/HarmonyPatches.cs
@@ -1,6 +1,10 @@
 ﻿// ReSharper disable RedundantUsingDirective, needed for debugging
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using HarmonyLib;
 using RimWorld;
 using UnityEngine;
@@ -9,6 +13,81 @@ using Random = System.Random;
 
 namespace LaptopBatteryStatus;
 
+internal static class OSVariants
+{
+    public static OSPlatform SteamOS { get; } = OSPlatform.Create("STEAMOS");
+    public static OSPlatform SteamDeck { get; } = OSPlatform.Create("STEAMDECK"); // The SteamDeck's main OS, which is a varient of SteamOS
+
+    // Steam's runtime system; depending on version this could be linker (LD_LIBARY_PATH) based or container based. This is what's normally visible to games.
+    // See https://github.com/ValveSoftware/steam-runtime
+    public static OSPlatform SteamLinuxRuntime { get; } = OSPlatform.Create("STEAMRT");
+
+    public static OSPlatform GetRuntimeOS()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return OSPlatform.Windows;
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return OSPlatform.OSX;
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            try
+            {
+                Dictionary<string, string> osRelease = ParseOSRelease("/etc/os-release");
+                if (osRelease.GetValueOrDefault("ID") == "steamos")
+                {
+                    if (osRelease.GetValueOrDefault("VARIANT_ID") == "steamdeck")
+                        return SteamDeck;
+                    else
+                        return SteamOS;
+                }
+                else if (osRelease.GetValueOrDefault("ID") == "steamrt")
+                {
+                    return SteamLinuxRuntime;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warning("[LaptopBatteryStatus] Error while parsing os-release; battery status may not work.");
+                Log.Message(e.ToString());
+            }
+            return OSPlatform.Linux;
+        }
+        else
+        {
+            Log.Warning("[LaptopBatteryStatus] Unknown OS detected; battery status may not work.");
+            return OSPlatform.Create("UNKNOWN");
+        }
+    }
+
+    private static Dictionary<string, string> ParseOSRelease(string path)
+    {
+        // Regex matches <optionally quoted string> = <optionally quoted string>
+        Regex r = new(@"""?([^""=]+)""?\s*=\s*""?([^""=]+)""?");
+
+        Dictionary<string, string> rc = new();
+        foreach (string fullLine in File.ReadAllLines(path))
+        {
+            if (string.IsNullOrWhiteSpace(fullLine))
+                continue;
+            string line = fullLine.TrimStart();
+            if (line.StartsWith("#"))
+                continue;
+            Match m = r.Match(line);
+            if (m.Success)
+                rc.Add(m.Groups[1].Value, m.Groups[2].Value);
+        }
+        return rc;
+    }
+
+    public static bool IsLinuxLike(this OSPlatform os)
+    {
+        return os.Equals(OSPlatform.Linux) ||
+               os.Equals(SteamLinuxRuntime) ||
+               os.Equals(SteamOS) ||
+               os.Equals(SteamDeck);
+    }
+}
+
 [StaticConstructorOnStartup]
 internal class HarmonyPatches
 {
@@ -16,15 +95,79 @@ internal class HarmonyPatches
     private static float lastBatteryPercent;
     private static BatteryStatus cachedBatteryStatus;
     private static int timeToUpdate;
+    private static string linuxBatteryPath;
+    private static readonly OSPlatform runtimeOS;
 
     static HarmonyPatches()
     {
-        cachedBatteryPercent = SystemInfo.batteryLevel;
-        cachedBatteryStatus = SystemInfo.batteryStatus;
+        runtimeOS = OSVariants.GetRuntimeOS();
+#if DEBUG
+        Verse.Log.Message( "[LaptopBatteryStatus] RuntimeInformation.IsOSPlatform is Linux? " + RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+        Verse.Log.Message($"[LaptopBatteryStatus] RuntimeInformation.OSDescription is [{RuntimeInformation.OSDescription}]");
+        Verse.Log.Message( "[LaptopBatteryStatus] Detected OS is " + runtimeOS.ToString());
+#endif
+        linuxBatteryPath = null;
+        if (runtimeOS.IsLinuxLike())
+        {
+            // SteamDecks have their battery at /sys/class/power_supply/BAT1, which is weird.
+            // The main system battery is usually at BAT0. Thus, we shouldn't hard code the path
+            // since this might change in the future. (Besides, hardcoding is yucky.) Instead,
+            // use the first BAT* path that contains the "files" that we need.
+            // If we don't find any, no worries. We'll try the method used for all the other systems.
+            foreach (string d in Directory.GetDirectories("/sys/class/power_supply/", "BAT*"))
+            {
+                string dir = d + "/";
+#if DEBUG
+                Log.Message($"[LaptopBatteryStatus] checking battery candidate [{dir}]");
+#endif
+                if (File.Exists(dir + "status") &&
+                    File.Exists(dir + "capacity"))
+                {
+                    linuxBatteryPath = dir;
+                    break;
+                }
+
+            }
+#if DEBUG
+            Log.Message($"[LaptopBatteryStatus] Using battery at path [{linuxBatteryPath}]");
+#endif
+        }
+        UpdateBatteryCache();
         timeToUpdate = 0;
         var harmony = new Harmony("Mlie.LaptopBatteryStatus");
         harmony.Patch(AccessTools.Method(typeof(GlobalControlsUtility), nameof(GlobalControlsUtility.DoDate)), null,
             new HarmonyMethod(typeof(HarmonyPatches), nameof(BatteryStatus_NearDatePostfix)));
+    }
+
+    private static void UpdateBatteryCache()
+    {
+        // This may work for all Linux-like OSes but it is currently only tested on SteamDeck using steamrt
+        // Consider modifying the following gate on the runtimeOS if it's shown to work elsewhere
+        if (linuxBatteryPath != null && runtimeOS == OSVariants.SteamLinuxRuntime )
+        {
+            try
+            {
+                cachedBatteryPercent = int.Parse(File.ReadAllText(linuxBatteryPath + "/capacity").Trim()) / 100f;
+                string statusStr = File.ReadAllText(linuxBatteryPath + "/status").Trim();
+                if (!Enum.TryParse(statusStr, true, out cachedBatteryStatus))
+                {
+                    Log.WarningOnce($"[LaptopBatteryStatus] Unrecognized battery status: {statusStr}", statusStr.GetHashCodeSafe());
+                    cachedBatteryStatus = BatteryStatus.Unknown;
+                }
+                return;
+            }
+            catch (Exception e)
+            {
+                // If we fail, fall back to using Unity's built-in system. They might have fixed it by now.
+                Log.Warning("[LaptopBatteryStatus] Exception while getting battery status for Linux system. Falling back to Unity method.");
+                Log.Message(e.ToString());
+                linuxBatteryPath = null;
+            }
+        }
+
+        // If this isn't linux, or getting data from the linux system failed, use Unity
+        cachedBatteryPercent = SystemInfo.batteryLevel;
+        cachedBatteryStatus = SystemInfo.batteryStatus;
     }
 
     private static void UpdateValuesIfNeeded()
@@ -52,16 +195,14 @@ internal class HarmonyPatches
         {
             GameDataSaveLoader.SaveGame("BS.Filename".Translate(cachedBatteryPercent.ToStringPercent()));
         }
-
-        return;
-#endif
-        cachedBatteryPercent = SystemInfo.batteryLevel;
-        cachedBatteryStatus = SystemInfo.batteryStatus;
+#else // if !DEBUG
+        UpdateBatteryCache();
         if (LaptopBatteryStatusMod.settings.autosaveOn > cachedBatteryPercent &&
             LaptopBatteryStatusMod.settings.autosaveOn < lastBatteryPercent)
         {
             GameDataSaveLoader.SaveGame("BS.Filename".Translate(cachedBatteryPercent.ToStringPercent()));
         }
+#endif
     }
 
     private static void BatteryStatus_NearDatePostfix(ref float curBaseY)


### PR DESCRIPTION
I've got a SteamDeck and noticed that this mod doesn't detect the SteamDeck battery. It appears that Unity's battery functions either do not function properly on Linux or don't work within the SteamRT container used within the SteamDeck's version of SteamOS, which is based on Linux. I added code that detects this particular OS variant and uses the Linux kernel's sysfs battery APIs to provide the same information that Unity does on other platforms.

This should work under any Linux system, not just the SteamDeck. However, I chose to only use this method for the SteamRT container (aka SteamDeck) since I can't test it on other Linux systems. However, should someone be able to test that in the future, it would be easy to alter the code to support those OSes. I even added a comment in the appropriate location to do so. 